### PR TITLE
Update to jekyll 2.5.3 and minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A remote include plugin for Jekyll.
 It's like {% include file.html %} but instead of grabbing files from your _includes directory it gets the file from a remote URL.
 
 ```
-{% remote_include http://static.2inspire.co.uk/img/articles/vector.svg %}
+{% remote_include https://raw.githubusercontent.com/jekyll/jekyll/master/README.markdown %}
 ```
 
 ## Pull requests welcome

--- a/remote-include.rb
+++ b/remote-include.rb
@@ -2,20 +2,20 @@ require 'net/http'
 require 'uri'
 
 module Jekyll
+  
   class RemoteInclude < Liquid::Tag
   
     def initialize(tag_name, remote_include, tokens)
       super
+      @remote_include = remote_include
     end
     
-	def open(url)
-	  Net::HTTP.get(URI.parse(url))
-	end
+    def open(url)
+      Net::HTTP.get(URI.parse(url)).force_encoding 'utf-8'
+    end
     
     def render(context)
-    
-	open("#{context[@markup.strip]}")
-
+      open("#{@remote_include}")
     end
     
   end


### PR DESCRIPTION
jekyll 2.5.3 support
different encoding support (force content converting to utf-8)
improved formatting
markdown example in README.md