### PR TITLE
Fix #2: Strip whitespace from URI

### DIFF
--- a/remote-include.rb
+++ b/remote-include.rb
@@ -2,22 +2,22 @@ require 'net/http'
 require 'uri'
 
 module Jekyll
-  
+
   class RemoteInclude < Liquid::Tag
-  
+
     def initialize(tag_name, remote_include, tokens)
       super
       @remote_include = remote_include
     end
-    
+
     def open(url)
-      Net::HTTP.get(URI.parse(url)).force_encoding 'utf-8'
+      Net::HTTP.get(URI.parse(url.strip)).force_encoding 'utf-8'
     end
-    
+
     def render(context)
       open("#{@remote_include}")
     end
-    
+
   end
 end
 


### PR DESCRIPTION
This should be an easy fix for #2 where whitespace surrounding the URI breaks the URI parsing.